### PR TITLE
feat: scaffold TypeScript Pulumi provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+package-lock.json
+dist

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "openshift-pulumi-provider",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@pulumi/pulumi": "^3.192.0",
+    "yaml": "^2.8.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2"
+  },
+  "types": "dist/index.d.ts"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,5 @@
+export { MirrorRegistry, MirrorRegistryArgs } from "./resources/mirrorRegistry";
+export { InstallAssets, InstallAssetsArgs } from "./resources/installAssets";
+export { BmcVirtualMedia, BmcVirtualMediaArgs } from "./resources/bmcVirtualMedia";
+export { AgentInstall, AgentInstallArgs } from "./resources/agentInstall";
+export { OpenshiftAgentCluster, OpenshiftAgentClusterArgs } from "./resources/cluster";

--- a/src/resources/agentInstall.ts
+++ b/src/resources/agentInstall.ts
@@ -1,0 +1,43 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as fs from "fs";
+import * as path from "path";
+
+export interface AgentInstallArgs {
+  workdir: pulumi.Input<string>;
+  wait?: pulumi.Input<{ bootstrapTimeoutMins?: pulumi.Input<number>; installTimeoutMins?: pulumi.Input<number> }>;
+}
+
+export interface AgentInstallOutputs {
+  kubeconfig: pulumi.Output<string>;
+  kubeadminPassword: pulumi.Output<string>;
+  consoleURL: pulumi.Output<string>;
+}
+
+class AgentInstallProvider implements pulumi.dynamic.ResourceProvider {
+  public async create(inputs: any): Promise<pulumi.dynamic.CreateResult> {
+    const authDir = path.join(inputs.workdir, "auth");
+    fs.mkdirSync(authDir, { recursive: true });
+    const kubeconfigPath = path.join(authDir, "kubeconfig");
+    const passwordPath = path.join(authDir, "kubeadmin-password");
+    fs.writeFileSync(kubeconfigPath, "apiVersion: v1\nclusters: []\n", { encoding: "utf8" });
+    fs.writeFileSync(passwordPath, "changeme", { encoding: "utf8" });
+    return {
+      id: inputs.workdir,
+      outs: {
+        kubeconfig: fs.readFileSync(kubeconfigPath, "utf8"),
+        kubeadminPassword: fs.readFileSync(passwordPath, "utf8"),
+        consoleURL: "https://console-openshift.example.com",
+      },
+    };
+  }
+}
+
+export class AgentInstall extends pulumi.dynamic.Resource implements AgentInstallOutputs {
+  public readonly kubeconfig!: pulumi.Output<string>;
+  public readonly kubeadminPassword!: pulumi.Output<string>;
+  public readonly consoleURL!: pulumi.Output<string>;
+
+  constructor(name: string, args: AgentInstallArgs, opts?: pulumi.CustomResourceOptions) {
+    super(new AgentInstallProvider(), name, { ...args, kubeconfig: undefined, kubeadminPassword: undefined, consoleURL: undefined }, opts);
+  }
+}

--- a/src/resources/bmcVirtualMedia.ts
+++ b/src/resources/bmcVirtualMedia.ts
@@ -1,0 +1,39 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export interface BmcVirtualMediaArgs {
+  redfishEndpoint: pulumi.Input<string>;
+  username: pulumi.Input<string>;
+  password: pulumi.Input<string>;
+  isoURL: pulumi.Input<string>;
+  bootDevice?: pulumi.Input<string>;
+  powerAction?: pulumi.Input<string>;
+}
+
+export interface BmcVirtualMediaOutputs {
+  lastAction: pulumi.Output<string>;
+  mounted: pulumi.Output<boolean>;
+  lastTaskState: pulumi.Output<string>;
+}
+
+class BmcProvider implements pulumi.dynamic.ResourceProvider {
+  public async create(_inputs: any): Promise<pulumi.dynamic.CreateResult> {
+    return {
+      id: "bmc",
+      outs: {
+        lastAction: "none",
+        mounted: false,
+        lastTaskState: "unknown",
+      },
+    };
+  }
+}
+
+export class BmcVirtualMedia extends pulumi.dynamic.Resource implements BmcVirtualMediaOutputs {
+  public readonly lastAction!: pulumi.Output<string>;
+  public readonly mounted!: pulumi.Output<boolean>;
+  public readonly lastTaskState!: pulumi.Output<string>;
+
+  constructor(name: string, args: BmcVirtualMediaArgs, opts?: pulumi.CustomResourceOptions) {
+    super(new BmcProvider(), name, { ...args, lastAction: undefined, mounted: undefined, lastTaskState: undefined }, opts);
+  }
+}

--- a/src/resources/cluster.ts
+++ b/src/resources/cluster.ts
@@ -1,0 +1,37 @@
+import * as pulumi from "@pulumi/pulumi";
+import { InstallAssets, InstallAssetsArgs } from "./installAssets";
+import { AgentInstall } from "./agentInstall";
+import { BmcVirtualMedia, BmcVirtualMediaArgs } from "./bmcVirtualMedia";
+
+export interface OpenshiftAgentClusterArgs extends InstallAssetsArgs {
+  bmc?: pulumi.Input<BmcVirtualMediaArgs[]>;
+}
+
+export class OpenshiftAgentCluster extends pulumi.ComponentResource {
+  public readonly kubeconfig: pulumi.Output<string>;
+  public readonly consoleURL: pulumi.Output<string>;
+
+  constructor(name: string, args: OpenshiftAgentClusterArgs, opts?: pulumi.ComponentResourceOptions) {
+    super("openshiftagent:OpenshiftAgentCluster", name, {}, opts);
+
+    const { bmc, ...assetArgs } = args;
+
+    const assets = new InstallAssets(`${name}-assets`, assetArgs, { parent: this });
+
+    const boots: BmcVirtualMedia[] = [];
+    if (bmc) {
+      pulumi.output(bmc).apply(hosts => {
+        hosts.forEach((h, idx) => {
+          boots.push(new BmcVirtualMedia(`${name}-bmc-${idx}`, h, { parent: this }));
+        });
+      });
+    }
+
+    const install = new AgentInstall(`${name}-install`, { workdir: assets.workdir }, { parent: this, dependsOn: boots });
+
+    this.kubeconfig = install.kubeconfig;
+    this.consoleURL = install.consoleURL;
+
+    this.registerOutputs({ kubeconfig: this.kubeconfig, consoleURL: this.consoleURL });
+  }
+}

--- a/src/resources/installAssets.ts
+++ b/src/resources/installAssets.ts
@@ -1,0 +1,107 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as yaml from "yaml";
+
+export interface NetworkingArgs {
+  clusterCIDR: pulumi.Input<string>;
+  serviceCIDR: pulumi.Input<string>;
+  machineCIDR: pulumi.Input<string>;
+  networkType: pulumi.Input<string>;
+}
+
+export interface AgentHostArgs {
+  hostname?: pulumi.Input<string>;
+  role?: pulumi.Input<string>;
+  macToIface: pulumi.Input<{ name: pulumi.Input<string>; mac: pulumi.Input<string> }[]>;
+}
+
+export interface AgentArgs {
+  rendezvousIP?: pulumi.Input<string>;
+  hosts?: pulumi.Input<AgentHostArgs[]>;
+}
+
+export interface InstallAssetsArgs {
+  releaseImage: pulumi.Input<string>;
+  baseDomain: pulumi.Input<string>;
+  clusterName: pulumi.Input<string>;
+  platform: pulumi.Input<string>;
+  networking: pulumi.Input<NetworkingArgs>;
+  controlPlaneReplicas: pulumi.Input<number>;
+  computeReplicas: pulumi.Input<number>;
+  pullSecret: pulumi.Input<string>;
+  sshPubKey: pulumi.Input<string>;
+  agent?: pulumi.Input<AgentArgs>;
+  mirror?: pulumi.Input<{ registriesConf?: pulumi.Input<string>; caBundle?: pulumi.Input<string> }>;
+  workdir?: pulumi.Input<string>;
+  serveFrom?: pulumi.Input<{ address: pulumi.Input<string>; port?: pulumi.Input<number> }>;
+  emitPXE?: pulumi.Input<boolean>;
+}
+
+export interface InstallAssetsOutputs {
+  isoPath: pulumi.Output<string>;
+  isoURL: pulumi.Output<string | undefined>;
+  workdir: pulumi.Output<string>;
+}
+
+class InstallAssetsProvider implements pulumi.dynamic.ResourceProvider {
+  public async create(inputs: any): Promise<pulumi.dynamic.CreateResult> {
+    const workdir = inputs.workdir || fs.mkdtempSync(path.join(os.tmpdir(), "assets-"));
+    fs.mkdirSync(workdir, { recursive: true });
+
+    const installConfig = {
+      apiVersion: "v1",
+      baseDomain: inputs.baseDomain,
+      metadata: { name: inputs.clusterName },
+      networking: inputs.networking,
+      compute: [{ name: "worker", replicas: inputs.computeReplicas }],
+      controlPlane: { name: "master", replicas: inputs.controlPlaneReplicas },
+      platform: { none: {} },
+      pullSecret: inputs.pullSecret,
+      sshKey: inputs.sshPubKey,
+    };
+    fs.writeFileSync(path.join(workdir, "install-config.yaml"), yaml.stringify(installConfig));
+
+    const agentConfig = {
+      apiVersion: "v1alpha1",
+      kind: "AgentConfig",
+      rendezvousIP: inputs.agent?.rendezvousIP,
+      hosts: inputs.agent?.hosts,
+    };
+    fs.writeFileSync(path.join(workdir, "agent-config.yaml"), yaml.stringify(agentConfig));
+
+    const isoPath = path.join(workdir, "agent.x86_64.iso");
+    fs.writeFileSync(isoPath, "");
+
+    let isoURL: string | undefined;
+    if (inputs.serveFrom) {
+      const port = inputs.serveFrom.port || 8080;
+      isoURL = `http://${inputs.serveFrom.address}:${port}/agent.x86_64.iso`;
+    }
+
+    return {
+      id: workdir,
+      outs: {
+        isoPath,
+        isoURL,
+        workdir,
+      },
+    };
+  }
+}
+
+export class InstallAssets extends pulumi.dynamic.Resource implements InstallAssetsOutputs {
+  public readonly isoPath!: pulumi.Output<string>;
+  public readonly isoURL!: pulumi.Output<string | undefined>;
+  public readonly workdir!: pulumi.Output<string>;
+
+  constructor(name: string, args: InstallAssetsArgs, opts?: pulumi.CustomResourceOptions) {
+    super(new InstallAssetsProvider(), name, {
+      ...args,
+      isoPath: undefined,
+      isoURL: undefined,
+      workdir: undefined,
+    }, opts);
+  }
+}

--- a/src/resources/mirrorRegistry.ts
+++ b/src/resources/mirrorRegistry.ts
@@ -1,0 +1,65 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+export interface MirrorRegistryArgs {
+  enabled: pulumi.Input<boolean>;
+  archivePath?: pulumi.Input<string>;
+  imageSetConfig?: pulumi.Input<string>;
+  registryHost?: pulumi.Input<string>;
+  tls?: pulumi.Input<{
+    caBundle?: pulumi.Input<string>;
+    skipVerify?: pulumi.Input<boolean>;
+  }>;
+}
+
+export interface MirrorRegistryOutputs {
+  endpoint: pulumi.Output<string>;
+  authFilePath: pulumi.Output<string>;
+  registriesConf: pulumi.Output<string>;
+  caBundlePath: pulumi.Output<string>;
+}
+
+class MirrorRegistryProvider implements pulumi.dynamic.ResourceProvider {
+  public async create(inputs: any): Promise<pulumi.dynamic.CreateResult> {
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "mirror-"));
+    const endpoint = inputs.registryHost || "https://mirror.local";
+    const authFilePath = path.join(workdir, "auth.json");
+    fs.writeFileSync(authFilePath, "{}", { encoding: "utf8" });
+    const registriesConf = path.join(workdir, "registries.conf");
+    fs.writeFileSync(registriesConf, "", { encoding: "utf8" });
+    const caBundlePath = inputs?.tls?.caBundle
+      ? path.join(workdir, "ca.pem")
+      : "";
+    if (inputs?.tls?.caBundle) {
+      fs.writeFileSync(caBundlePath, inputs.tls.caBundle, { encoding: "utf8" });
+    }
+    return {
+      id: workdir,
+      outs: {
+        endpoint,
+        authFilePath,
+        registriesConf,
+        caBundlePath,
+      },
+    };
+  }
+}
+
+export class MirrorRegistry extends pulumi.dynamic.Resource implements MirrorRegistryOutputs {
+  public readonly endpoint!: pulumi.Output<string>;
+  public readonly authFilePath!: pulumi.Output<string>;
+  public readonly registriesConf!: pulumi.Output<string>;
+  public readonly caBundlePath!: pulumi.Output<string>;
+
+  constructor(name: string, args: MirrorRegistryArgs, opts?: pulumi.CustomResourceOptions) {
+    super(new MirrorRegistryProvider(), name, {
+      ...args,
+      endpoint: undefined,
+      authFilePath: undefined,
+      registriesConf: undefined,
+      caBundlePath: undefined,
+    }, opts);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold TypeScript-based Pulumi provider for OpenShift agent installer
- add dynamic resources for mirror registry, install assets, BMC virtual media, agent install, and composite cluster

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b2d0a22f8c8320aace59a02a39973c