### PR TITLE
Implement real OpenShift agent workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "type": "commonjs",
   "dependencies": {
     "@pulumi/pulumi": "^3.192.0",
-    "yaml": "^2.8.1"
+    "yaml": "^2.8.1",
+    "ipaddr.js": "^2.2.0"
   },
   "devDependencies": {
     "typescript": "^5.9.2"

--- a/src/resources/bmcVirtualMedia.ts
+++ b/src/resources/bmcVirtualMedia.ts
@@ -16,13 +16,50 @@ export interface BmcVirtualMediaOutputs {
 }
 
 class BmcProvider implements pulumi.dynamic.ResourceProvider {
-  public async create(_inputs: any): Promise<pulumi.dynamic.CreateResult> {
+  public async create(inputs: any): Promise<pulumi.dynamic.CreateResult> {
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + Buffer.from(`${inputs.username}:${inputs.password}`).toString("base64"),
+    } as any;
+
+    const base = inputs.redfishEndpoint.replace(/\/$/, "");
+    const media = inputs.bootDevice || "Cd";
+    const insertUrl = `${base}/redfish/v1/Managers/1/VirtualMedia/${media}/Actions/VirtualMedia.InsertMedia`;
+
+    let mounted = false;
+    let lastTaskState = "unknown";
+    try {
+      await fetch(insertUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ Image: inputs.isoURL, Inserted: true }),
+      });
+      mounted = true;
+      lastTaskState = "Inserted";
+    } catch (e: any) {
+      lastTaskState = `error: ${e.message}`;
+    }
+
+    if (inputs.powerAction) {
+      const resetUrl = `${base}/redfish/v1/Systems/1/Actions/ComputerSystem.Reset`;
+      try {
+        await fetch(resetUrl, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ ResetType: inputs.powerAction }),
+        });
+        lastTaskState = inputs.powerAction;
+      } catch (e: any) {
+        lastTaskState = `error: ${e.message}`;
+      }
+    }
+
     return {
-      id: "bmc",
+      id: base,
       outs: {
-        lastAction: "none",
-        mounted: false,
-        lastTaskState: "unknown",
+        lastAction: inputs.powerAction || "insert",
+        mounted,
+        lastTaskState,
       },
     };
   }

--- a/src/resources/installAssets.ts
+++ b/src/resources/installAssets.ts
@@ -3,18 +3,20 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as yaml from "yaml";
+import { execSync } from "child_process";
+import * as ipaddr from "ipaddr.js";
 
 export interface NetworkingArgs {
   clusterCIDR: pulumi.Input<string>;
   serviceCIDR: pulumi.Input<string>;
   machineCIDR: pulumi.Input<string>;
-  networkType: pulumi.Input<string>;
+  networkType?: pulumi.Input<string>;
 }
 
 export interface AgentHostArgs {
   hostname?: pulumi.Input<string>;
   role?: pulumi.Input<string>;
-  macToIface: pulumi.Input<{ name: pulumi.Input<string>; mac: pulumi.Input<string> }[]>;
+  networkConfig: pulumi.Input<any>;
 }
 
 export interface AgentArgs {
@@ -33,7 +35,12 @@ export interface InstallAssetsArgs {
   pullSecret: pulumi.Input<string>;
   sshPubKey: pulumi.Input<string>;
   agent?: pulumi.Input<AgentArgs>;
-  mirror?: pulumi.Input<{ registriesConf?: pulumi.Input<string>; caBundle?: pulumi.Input<string> }>;
+  mirror?: pulumi.Input<{
+    endpoint: pulumi.Input<string>;
+    registriesConf?: pulumi.Input<string>;
+    caBundlePath?: pulumi.Input<string>;
+    authFilePath?: pulumi.Input<string>;
+  }>;
   workdir?: pulumi.Input<string>;
   serveFrom?: pulumi.Input<{ address: pulumi.Input<string>; port?: pulumi.Input<number> }>;
   emitPXE?: pulumi.Input<boolean>;
@@ -49,8 +56,31 @@ class InstallAssetsProvider implements pulumi.dynamic.ResourceProvider {
   public async create(inputs: any): Promise<pulumi.dynamic.CreateResult> {
     const workdir = inputs.workdir || fs.mkdtempSync(path.join(os.tmpdir(), "assets-"));
     fs.mkdirSync(workdir, { recursive: true });
+    // Default networking values and validations
+    inputs.networking = inputs.networking || {};
+    if (!inputs.networking.networkType) {
+      inputs.networking.networkType = "OVNKubernetes";
+    }
 
-    const installConfig = {
+    // Basic CIDR overlap validation
+    const cidrs = [inputs.networking.clusterCIDR, inputs.networking.serviceCIDR, inputs.networking.machineCIDR];
+    const parsed = cidrs.map((c: string) => ipaddr.parseCIDR(c));
+    const overlaps = (a: any, b: any) => a[0].match(b[0], Math.min(a[1], b[1]));
+    for (let i = 0; i < parsed.length; i++) {
+      for (let j = i + 1; j < parsed.length; j++) {
+        if (overlaps(parsed[i], parsed[j])) {
+          throw new Error("Networking CIDRs must not overlap");
+        }
+      }
+    }
+
+    // Multi node requires rendezvous IP
+    const totalReplicas = inputs.controlPlaneReplicas + inputs.computeReplicas;
+    if (totalReplicas > 1 && !inputs.agent?.rendezvousIP) {
+      throw new Error("rendezvousIP is required for multi-node clusters");
+    }
+
+    const installConfig: any = {
       apiVersion: "v1",
       baseDomain: inputs.baseDomain,
       metadata: { name: inputs.clusterName },
@@ -61,18 +91,76 @@ class InstallAssetsProvider implements pulumi.dynamic.ResourceProvider {
       pullSecret: inputs.pullSecret,
       sshKey: inputs.sshPubKey,
     };
+
+    // Mirror / disconnected support
+    if (inputs.mirror?.endpoint) {
+      installConfig.imageContentSources = [
+        { source: "quay.io/openshift-release-dev/ocp-release", mirrors: [inputs.mirror.endpoint] },
+        { source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev", mirrors: [inputs.mirror.endpoint] },
+      ];
+    }
+    if (inputs.mirror?.caBundlePath) {
+      installConfig.additionalTrustBundle = fs.readFileSync(inputs.mirror.caBundlePath, "utf8");
+    }
+
     fs.writeFileSync(path.join(workdir, "install-config.yaml"), yaml.stringify(installConfig));
+
+    const machineNet = ipaddr.parseCIDR(inputs.networking.machineCIDR);
+    const hosts = (inputs.agent?.hosts || []).map((h: any) => {
+      const cfg = typeof h.networkConfig === "string" ? yaml.parse(h.networkConfig) : h.networkConfig;
+      const interfaces = cfg?.interfaces || [];
+      interfaces.forEach((iface: any) => {
+        (iface.ipv4?.address || []).forEach((addr: any) => {
+          if (!ipaddr.parse(addr.ip).match(machineNet[0], machineNet[1])) {
+            throw new Error(`Host ${h.hostname || ""} IP ${addr.ip} not in machineCIDR`);
+          }
+        });
+      });
+      return {
+        hostname: h.hostname,
+        role: h.role,
+        networkConfig: h.networkConfig,
+      };
+    });
 
     const agentConfig = {
       apiVersion: "v1alpha1",
       kind: "AgentConfig",
       rendezvousIP: inputs.agent?.rendezvousIP,
-      hosts: inputs.agent?.hosts,
+      hosts,
     };
     fs.writeFileSync(path.join(workdir, "agent-config.yaml"), yaml.stringify(agentConfig));
 
+    // Invoke openshift-install to create ISO and optional PXE artifacts
+    const env = { ...process.env } as any;
+    if (inputs.mirror?.authFilePath) {
+      env.REGISTRY_AUTH_FILE = inputs.mirror.authFilePath;
+    }
+    if (inputs.releaseImage) {
+      env.OPENSHIFT_INSTALL_RELEASE_IMAGE = inputs.releaseImage;
+    }
+
+    let cmd = `openshift-install agent create image --dir ${workdir}`;
+    if (inputs.releaseImage) {
+      cmd += ` --release-image ${inputs.releaseImage}`;
+    }
+    if (inputs.mirror?.registriesConf) {
+      cmd += ` --registry-config ${inputs.mirror.registriesConf}`;
+    }
+    execSync(cmd, { env, stdio: "inherit" });
+
+    if (inputs.emitPXE) {
+      let pxeCmd = `openshift-install agent create boot-artifacts --dir ${workdir}`;
+      if (inputs.releaseImage) {
+        pxeCmd += ` --release-image ${inputs.releaseImage}`;
+      }
+      if (inputs.mirror?.registriesConf) {
+        pxeCmd += ` --registry-config ${inputs.mirror.registriesConf}`;
+      }
+      execSync(pxeCmd, { env, stdio: "inherit" });
+    }
+
     const isoPath = path.join(workdir, "agent.x86_64.iso");
-    fs.writeFileSync(isoPath, "");
 
     let isoURL: string | undefined;
     if (inputs.serveFrom) {


### PR DESCRIPTION
## Summary
- run `openshift-install` to create agent ISOs and optional PXE artifacts
- wait for cluster install to finish and surface kubeconfig/password/console URL
- add network defaults/validation, mirror handling and nmstate host config
- implement Redfish virtual media actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b2d73eafe083209a861dfa429f19d6